### PR TITLE
build: reduce minimum go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/waduhek/flagger
 
-go 1.22.1
+go 1.21
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.1


### PR DESCRIPTION
Reduce the minimum go version to 1.21 in `go.mod` file.