### PR TITLE
refactor: convert repository and model interfaces to generic interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/waduhek/flagger
 
-go 1.21
+go 1.22
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/internal/environment/data_model.go
+++ b/internal/environment/data_model.go
@@ -3,17 +3,14 @@ package environment
 import (
 	"context"
 	"time"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type Environment struct {
-	ID        primitive.ObjectID `bson:"_id,omitempty"`
-	Name      string             `bson:"name"`
-	ProjectID primitive.ObjectID `bson:"project_id"`
-	CreatedBy primitive.ObjectID `bson:"created_by"`
-	CreatedAt time.Time          `bson:"created_at"`
+	ID        string
+	Name      string
+	ProjectID string
+	CreatedBy string
+	CreatedAt time.Time
 }
 
 type DataRepository interface {
@@ -21,15 +18,15 @@ type DataRepository interface {
 	Save(
 		ctx context.Context,
 		environment *Environment,
-	) (*mongo.InsertOneResult, error)
+	) (string, error)
 
 	// Gets an `Environment` by it's object ID.
-	GetByID(ctx context.Context, id primitive.ObjectID) (*Environment, error)
+	GetByID(ctx context.Context, id string) (*Environment, error)
 
 	// Gets an environment by it's name and the project ID.
 	GetByNameAndProjectID(
 		ctx context.Context,
 		environmentName string,
-		projectID primitive.ObjectID,
+		projectID string,
 	) (*Environment, error)
 }

--- a/internal/environment/mongo_repo.go
+++ b/internal/environment/mongo_repo.go
@@ -2,12 +2,25 @@ package environment
 
 import (
 	"context"
+	"errors"
+	"log"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+// environmentMongoModel is the MongoDB representation of the `Environment`
+// struct.
+type environmentMongoModel struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty"`
+	Name      string             `bson:"name"`
+	ProjectID primitive.ObjectID `bson:"project_id"`
+	CreatedBy primitive.ObjectID `bson:"created_by"`
+	CreatedAt time.Time          `bson:"created_at"`
+}
 
 const environmentCollection string = "environments"
 
@@ -18,44 +31,108 @@ type MongoDataRepository struct {
 func (r *MongoDataRepository) Save(
 	ctx context.Context,
 	environment *Environment,
-) (*mongo.InsertOneResult, error) {
-	return r.coll.InsertOne(ctx, environment)
+) (string, error) {
+	projectIDObjID, projectIDObjIDErr := primitive.ObjectIDFromHex(environment.ProjectID)
+	if projectIDObjIDErr != nil {
+		log.Printf("could not convert project id to object id: %v", projectIDObjIDErr)
+		return "", ErrCouldNotSave
+	}
+
+	createdByObjID, createdByObjIDErr := primitive.ObjectIDFromHex(environment.CreatedBy)
+	if createdByObjIDErr != nil {
+		log.Printf("could not convert created by id to object id: %v", createdByObjIDErr)
+		return "", ErrCouldNotSave
+	}
+
+	environmentToAdd := &environmentMongoModel{
+		Name:      environment.Name,
+		ProjectID: projectIDObjID,
+		CreatedBy: createdByObjID,
+		CreatedAt: time.Now(),
+	}
+
+	saveResult, saveErr := r.coll.InsertOne(ctx, environmentToAdd)
+	if saveErr != nil {
+		if mongo.IsDuplicateKeyError(saveErr) {
+			log.Printf("an environment with name %q exists", environment.Name)
+			return "", ErrNameTaken
+		}
+
+		log.Printf("error occurred while saving environment: %v", saveErr)
+		return "", ErrCouldNotSave
+	}
+
+	environmentID, ok := saveResult.InsertedID.(primitive.ObjectID)
+	if !ok {
+		log.Printf("could not assert saved environment id as object id")
+		return "", ErrCouldNotSave
+	}
+
+	return environmentID.Hex(), nil
 }
 
 func (r *MongoDataRepository) GetByID(
 	ctx context.Context,
-	id primitive.ObjectID,
+	id string,
 ) (*Environment, error) {
-	query := bson.D{{Key: "_id", Value: id}}
-
-	var environment Environment
-
-	err := r.coll.FindOne(ctx, query).Decode(&environment)
-	if err != nil {
-		return nil, err
+	environmentID, environmentIDErr := primitive.ObjectIDFromHex(id)
+	if environmentIDErr != nil {
+		log.Printf("error while converting environment id to object id: %v", environmentIDErr)
+		return nil, ErrCouldNotFetch
 	}
 
-	return &environment, nil
+	query := bson.D{{Key: "_id", Value: environmentID}}
+
+	var decodedEnvironment environmentMongoModel
+
+	err := r.coll.FindOne(ctx, query).Decode(&decodedEnvironment)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			log.Printf("no environment with the id %q was found: %v", id, err)
+			return nil, ErrNotFound
+		}
+
+		log.Printf("error occurred while fetching environment: %v", err)
+		return nil, ErrCouldNotFetch
+	}
+
+	return mapMongoModelToStruct(&decodedEnvironment), nil
 }
 
 func (r *MongoDataRepository) GetByNameAndProjectID(
 	ctx context.Context,
 	environmentName string,
-	projectID primitive.ObjectID,
+	projectID string,
 ) (*Environment, error) {
-	query := bson.D{
-		{Key: "name", Value: environmentName},
-		{Key: "project_id", Value: projectID},
+	projectIDObjID, projectIDObjIDErr := primitive.ObjectIDFromHex(projectID)
+	if projectIDObjIDErr != nil {
+		log.Printf("could not convert project id to object id: %v", projectIDObjIDErr)
+		return nil, ErrCouldNotFetch
 	}
 
-	var environment Environment
+	query := bson.D{
+		{Key: "name", Value: environmentName},
+		{Key: "project_id", Value: projectIDObjID},
+	}
 
-	err := r.coll.FindOne(ctx, query).Decode(&environment)
+	var decodedEnvironment environmentMongoModel
+
+	err := r.coll.FindOne(ctx, query).Decode(&decodedEnvironment)
 	if err != nil {
 		return nil, err
 	}
 
-	return &environment, nil
+	return mapMongoModelToStruct(&decodedEnvironment), nil
+}
+
+func mapMongoModelToStruct(decodedEnvironment *environmentMongoModel) *Environment {
+	return &Environment{
+		ID:        decodedEnvironment.ID.Hex(),
+		Name:      decodedEnvironment.Name,
+		ProjectID: decodedEnvironment.ID.Hex(),
+		CreatedBy: decodedEnvironment.CreatedBy.Hex(),
+		CreatedAt: decodedEnvironment.CreatedAt,
+	}
 }
 
 func setupCollIndexes(

--- a/internal/environment/service.go
+++ b/internal/environment/service.go
@@ -40,8 +40,7 @@ func (s *Server) CreateEnvironment(
 
 	fetchedUser, err := s.userDataRepo.GetByUsername(ctx, username)
 	if err != nil {
-		log.Printf("error while fetching user %q: %v", username, err)
-		return nil, user.ErrCouldNotFetch
+		return nil, err
 	}
 
 	projectName := req.GetProjectName()

--- a/internal/environment/service.go
+++ b/internal/environment/service.go
@@ -102,30 +102,9 @@ func (s *Server) handleCreateEnvrionment(
 			CreatedAt: time.Now(),
 		}
 
-		envResult, envSaveErr := s.environmentDataRepo.Save(ctx, &newEnvironment)
+		environmentID, envSaveErr := s.environmentDataRepo.Save(ctx, &newEnvironment)
 		if envSaveErr != nil {
-			if mongo.IsDuplicateKeyError(envSaveErr) {
-				log.Printf(
-					"an environment %q already exists for project %q",
-					environmentName,
-					fetchedProject.Name,
-				)
-				return nil, ErrNameTaken
-			}
-
-			log.Printf(
-				"could not create environment %q for project %q",
-				environmentName,
-				fetchedProject.ID,
-			)
-			return nil, ErrCouldNotSave
-		}
-
-		// Cast the returned ID of the inserted environment as an ObjectID.
-		environmentID, ok := envResult.InsertedID.(primitive.ObjectID)
-		if !ok {
-			log.Printf("environment ID is not of type ObjectID")
-			return nil, ErrEnvironmentIDCast
+			return nil, envSaveErr
 		}
 
 		// Create new flag settings for all the flags that are present in the

--- a/internal/environment/service.go
+++ b/internal/environment/service.go
@@ -130,7 +130,7 @@ func (s *Server) handleCreateEnvrionment(
 			)
 			if flagSettingSaveErr != nil {
 				log.Printf("error while saving flag settings: %v", flagSettingSaveErr)
-				return nil, flagsetting.ErrCouldNotSave
+				return nil, flagSettingSaveErr
 			}
 
 			// Update the project with the new flag settings.

--- a/internal/environment/service.go
+++ b/internal/environment/service.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/waduhek/flagger/proto/environmentpb"
@@ -125,22 +124,13 @@ func (s *Server) handleCreateEnvrionment(
 
 		// Save the flag settings to the collection.
 		if len(flagSettings) > 0 {
-			insertedFlagSettings, flagSettingSaveErr := s.flagSettingDataRepo.SaveMany(
+			insertedFlagSettingIDs, flagSettingSaveErr := s.flagSettingDataRepo.SaveMany(
 				ctx,
 				flagSettings,
 			)
 			if flagSettingSaveErr != nil {
 				log.Printf("error while saving flag settings: %v", flagSettingSaveErr)
 				return nil, flagsetting.ErrCouldNotSave
-			}
-
-			// Cast the IDs of all the flag settings as ObjectIDs.
-			var insertedFlagSettingIDs []primitive.ObjectID
-			for _, id := range insertedFlagSettings.InsertedIDs {
-				insertedFlagSettingIDs = append(
-					insertedFlagSettingIDs,
-					id.(primitive.ObjectID),
-				)
 			}
 
 			// Update the project with the new flag settings.

--- a/internal/environment/service.go
+++ b/internal/environment/service.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"context"
-	"errors"
 	"log"
 	"time"
 
@@ -53,17 +52,7 @@ func (s *Server) CreateEnvironment(
 		fetchedUser.ID,
 	)
 	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			log.Printf(
-				"no projects were found with name %q with user %q",
-				projectName,
-				username,
-			)
-			return nil, project.ErrNotFound
-		}
-
-		log.Printf("error occurred while fetching projects: %v", err)
-		return nil, project.ErrCouldNotFetch
+		return nil, err
 	}
 
 	// Create a session that will initiate a transaction to save the details of
@@ -182,11 +171,7 @@ func (s *Server) handleCreateEnvrionment(
 				insertedFlagSettingIDs...,
 			)
 			if projectFlagSettingErr != nil {
-				log.Printf(
-					"error while updating project with flag settings: %v",
-					projectFlagSettingErr,
-				)
-				return nil, project.ErrAddFlagSetting
+				return nil, projectFlagSettingErr
 			}
 		}
 
@@ -197,13 +182,7 @@ func (s *Server) handleCreateEnvrionment(
 			environmentID,
 		)
 		if projectUpdateErr != nil {
-			log.Printf(
-				"error while adding environment %q to project %q: %v",
-				environmentID,
-				fetchedProject.ID,
-				projectUpdateErr,
-			)
-			return nil, project.ErrAddEnvironment
+			return nil, projectUpdateErr
 		}
 
 		return nil, nil

--- a/internal/flag/data_model.go
+++ b/internal/flag/data_model.go
@@ -3,31 +3,28 @@ package flag
 import (
 	"context"
 	"time"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type Flag struct {
-	ID        primitive.ObjectID `bson:"_id,omitempty"`
-	Name      string             `bson:"name"`
-	ProjectID primitive.ObjectID `bson:"project_id"`
-	CreatedBy primitive.ObjectID `bson:"created_by"`
-	CreatedAt time.Time          `bson:"created_at"`
+	ID        string
+	Name      string
+	ProjectID string
+	CreatedBy string
+	CreatedAt time.Time
 }
 
 type DataRepository interface {
 	// Save creates a new `Flag` document.
-	Save(ctx context.Context, flag *Flag) (*mongo.InsertOneResult, error)
+	Save(ctx context.Context, flag *Flag) (string, error)
 
 	// GetByID gets a `Flag` by it's object ID.
-	GetByID(ctx context.Context, flagID primitive.ObjectID) (*Flag, error)
+	GetByID(ctx context.Context, flagID string) (*Flag, error)
 
 	// GetByNameAndProjectID gets a `Flag` by it's name and the ID of the
 	// project that it belongs to.
 	GetByNameAndProjectID(
 		ctx context.Context,
 		flagName string,
-		projectID primitive.ObjectID,
+		projectID string,
 	) (*Flag, error)
 }

--- a/internal/flag/service.go
+++ b/internal/flag/service.go
@@ -228,17 +228,7 @@ func (s *Server) UpdateFlagStatus(
 		fetchedProject.ID,
 	)
 	if err != nil {
-		log.Printf(
-			"error while fetching environment %q: %v",
-			environmentName,
-			err,
-		)
-
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, environment.ErrNotFound
-		}
-
-		return nil, environment.ErrCouldNotFetch
+		return nil, err
 	}
 
 	// Get the flag to update.

--- a/internal/flag/service.go
+++ b/internal/flag/service.go
@@ -60,18 +60,7 @@ func (s *Server) CreateFlag(
 		fetchedUser.ID,
 	)
 	if err != nil {
-		log.Printf(
-			"error while getting project %q with user %q: %v",
-			projectName,
-			username,
-			err,
-		)
-
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, project.ErrNotFound
-		}
-
-		return nil, project.ErrCouldNotFetch
+		return nil, err
 	}
 
 	// If there are no environments configured for the project, don't allow any
@@ -182,12 +171,7 @@ func (s *Server) handleCreateFlag(
 			savedFlagID,
 		)
 		if projectFlagUpdateErr != nil {
-			log.Printf(
-				"error while updating project with the flag: %v",
-				projectFlagUpdateErr,
-			)
-
-			return nil, project.ErrAddFlag
+			return nil, projectFlagUpdateErr
 		}
 
 		// Add all the object IDs of the flag settings to the project.
@@ -197,12 +181,7 @@ func (s *Server) handleCreateFlag(
 			flagSettingIDs...,
 		)
 		if projectSettingErr != nil {
-			log.Printf(
-				"error while updating project with flag settings: %v",
-				projectSettingErr,
-			)
-
-			return nil, project.ErrAddFlagSetting
+			return nil, projectSettingErr
 		}
 
 		return nil, nil
@@ -239,13 +218,7 @@ func (s *Server) UpdateFlagStatus(
 		fetchedUser.ID,
 	)
 	if err != nil {
-		log.Printf("error while fetching project %q: %v", projectName, err)
-
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, project.ErrNotFound
-		}
-
-		return nil, project.ErrCouldNotFetch
+		return nil, err
 	}
 
 	// Get the environment that is to be updated.

--- a/internal/flag/service.go
+++ b/internal/flag/service.go
@@ -45,8 +45,7 @@ func (s *Server) CreateFlag(
 
 	fetchedUser, err := s.userDataRepo.GetByUsername(ctx, username)
 	if err != nil {
-		log.Printf("error while fetching user %q: %v", username, err)
-		return nil, user.ErrCouldNotFetch
+		return nil, err
 	}
 
 	projectName := req.GetProjectName()
@@ -225,8 +224,7 @@ func (s *Server) UpdateFlagStatus(
 
 	fetchedUser, err := s.userDataRepo.GetByUsername(ctx, username)
 	if err != nil {
-		log.Printf("error while fetching user %q: %v", username, err)
-		return nil, user.ErrCouldNotFetch
+		return nil, err
 	}
 
 	projectName := req.GetProjectName()

--- a/internal/flag/service.go
+++ b/internal/flag/service.go
@@ -114,19 +114,10 @@ func (s *Server) handleCreateFlag(
 			CreatedAt: time.Now(),
 		}
 
-		flagSaveResult, err := s.flagDataRepo.Save(ctx, newFlag)
+		savedFlagID, err := s.flagDataRepo.Save(ctx, newFlag)
 		if err != nil {
-			log.Printf("error while saving the flag: %v", err)
-
-			if mongo.IsDuplicateKeyError(err) {
-				return nil, ErrNameTaken
-			}
-
-			return nil, ErrCouldNotSave
+			return nil, err
 		}
-
-		// Cast the returned ID of the saved flag as an ObjectID.
-		savedFlagID, _ := flagSaveResult.InsertedID.(primitive.ObjectID)
 
 		// Get all the environments that the project has.
 		projectEnvIDs := fetchedProject.Environments
@@ -238,13 +229,7 @@ func (s *Server) UpdateFlagStatus(
 		fetchedProject.ID,
 	)
 	if err != nil {
-		log.Printf("error while fetching flag %q: %v", flagName, err)
-
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, ErrNotFound
-		}
-
-		return nil, ErrCouldNotFetch
+		return nil, err
 	}
 
 	// Update the flag setting to the desired value.

--- a/internal/flag/service.go
+++ b/internal/flag/service.go
@@ -143,8 +143,7 @@ func (s *Server) handleCreateFlag(
 		)
 		if err != nil {
 			log.Printf("error while saving flag settings: %v", err)
-
-			return nil, flagsetting.ErrCouldNotSave
+			return nil, err
 		}
 
 		// Add the flag's object ID to the list of flags in the project.

--- a/internal/flagsetting/data_model.go
+++ b/internal/flagsetting/data_model.go
@@ -3,19 +3,16 @@ package flagsetting
 import (
 	"context"
 	"time"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type FlagSetting struct {
-	ID            primitive.ObjectID `bson:"_id,omitempty"`
-	ProjectID     primitive.ObjectID `bson:"project_id"`
-	EnvironmentID primitive.ObjectID `bson:"environment_id"`
-	FlagID        primitive.ObjectID `bson:"flag_id"`
-	IsActive      bool               `bson:"is_active"`
-	CreatedAt     time.Time          `bson:"created_at"`
-	UpdatedAt     time.Time          `bson:"updated_at"`
+	ID            string
+	ProjectID     string
+	EnvironmentID string
+	FlagID        string
+	IsActive      bool
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
 }
 
 type DataRepository interface {
@@ -23,30 +20,30 @@ type DataRepository interface {
 	Save(
 		ctx context.Context,
 		flagSetting *FlagSetting,
-	) (*mongo.InsertOneResult, error)
+	) (string, error)
 
 	// SaveMany creates multiple `FlagSetting`s.
 	SaveMany(
 		ctx context.Context,
 		flagSettings []FlagSetting,
-	) (*mongo.InsertManyResult, error)
+	) ([]string, error)
 
 	// Get gets the flag setting by the project ID, environment ID and the
 	// flag ID.
 	Get(
 		ctx context.Context,
-		projectID primitive.ObjectID,
-		environmentID primitive.ObjectID,
-		flagID primitive.ObjectID,
+		projectID string,
+		environmentID string,
+		flagID string,
 	) (*FlagSetting, error)
 
 	// UpdateIsActive updates a flag setting's `IsActive` field to the provided
 	// value.
 	UpdateIsActive(
 		ctx context.Context,
-		projectID primitive.ObjectID,
-		environmentID primitive.ObjectID,
-		flagID primitive.ObjectID,
+		projectID string,
+		environmentID string,
+		flagID string,
 		isActive bool,
-	) (*mongo.UpdateResult, error)
+	) (uint, error)
 }

--- a/internal/flagsetting/mongo_repo.go
+++ b/internal/flagsetting/mongo_repo.go
@@ -2,6 +2,8 @@ package flagsetting
 
 import (
 	"context"
+	"log"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -11,6 +13,18 @@ import (
 
 const flagSettingCollection string = "flag_settings"
 
+// flagSettingMongoModel is the MongoDB representation of the `FlagSetting`
+// struct.
+type flagSettingMongoModel struct {
+	ID            primitive.ObjectID `bson:"_id,omitempty"`
+	ProjectID     primitive.ObjectID `bson:"project_id"`
+	EnvironmentID primitive.ObjectID `bson:"environment_id"`
+	FlagID        primitive.ObjectID `bson:"flag_id"`
+	IsActive      bool               `bson:"is_active"`
+	CreatedAt     time.Time          `bson:"created_at"`
+	UpdatedAt     time.Time          `bson:"updated_at"`
+}
+
 type MongoDataRepository struct {
 	coll *mongo.Collection
 }
@@ -18,62 +32,194 @@ type MongoDataRepository struct {
 func (r *MongoDataRepository) Save(
 	ctx context.Context,
 	flagSetting *FlagSetting,
-) (*mongo.InsertOneResult, error) {
-	return r.coll.InsertOne(ctx, flagSetting)
+) (string, error) {
+	flagSettingToSave, createErr := createNewFlagSetting(flagSetting)
+	if createErr != nil {
+		return "", createErr
+	}
+
+	saveResult, saveErr := r.coll.InsertOne(ctx, flagSettingToSave)
+	if saveErr != nil {
+		if mongo.IsDuplicateKeyError(saveErr) {
+			log.Printf("got duplicate key error when saving flag setting: %v", saveErr)
+		} else {
+			log.Printf("error while saving flag setting: %v", saveErr)
+		}
+
+		return "", ErrCouldNotSave
+	}
+
+	flagSettingID, ok := saveResult.InsertedID.(primitive.ObjectID)
+	if !ok {
+		log.Printf("could not assert saved flag setting id as object id")
+		return "", ErrCouldNotSave
+	}
+
+	return flagSettingID.Hex(), nil
 }
 
 func (r *MongoDataRepository) SaveMany(
 	ctx context.Context,
 	flagSettings []FlagSetting,
-) (*mongo.InsertManyResult, error) {
-	var toInsert []interface{}
+) ([]string, error) {
+	toInsert := make([]interface{}, 0, len(flagSettings))
 	for _, setting := range flagSettings {
-		toInsert = append(toInsert, setting)
+		mongoModel, err := createNewFlagSetting(&setting)
+		if err != nil {
+			return []string{}, err
+		}
+
+		toInsert = append(toInsert, mongoModel)
 	}
 
-	return r.coll.InsertMany(ctx, toInsert)
+	saveResult, saveErr := r.coll.InsertMany(ctx, toInsert)
+	if saveErr != nil {
+		if mongo.IsDuplicateKeyError(saveErr) {
+			log.Printf("got duplicate key error while saving flag settings: %v", saveErr)
+		} else {
+			log.Printf("error while saving flag settings: %v", saveErr)
+		}
+
+		return []string{}, ErrCouldNotSave
+	}
+
+	savedIDs := make([]string, 0, len(saveResult.InsertedIDs))
+	for _, id := range saveResult.InsertedIDs {
+		flagSettingID, ok := id.(primitive.ObjectID)
+		if !ok {
+			log.Printf("could not assert save flag setting id as object id")
+			return []string{}, ErrCouldNotSave
+		}
+
+		savedIDs = append(savedIDs, flagSettingID.Hex())
+	}
+
+	return savedIDs, nil
+}
+
+func createNewFlagSetting(flagSetting *FlagSetting) (*flagSettingMongoModel, error) {
+	projectIDObjID, projectIDErr := primitive.ObjectIDFromHex(flagSetting.ProjectID)
+	if projectIDErr != nil {
+		log.Printf("could not convert project id to object id: %v", projectIDErr)
+		return nil, ErrCouldNotSave
+	}
+
+	environmentIDObjID, environmentIDErr := primitive.ObjectIDFromHex(flagSetting.EnvironmentID)
+	if environmentIDErr != nil {
+		log.Printf("could not convert environment id to object id: %v", environmentIDErr)
+		return nil, ErrCouldNotSave
+	}
+
+	flagIDObjID, flagIDErr := primitive.ObjectIDFromHex(flagSetting.FlagID)
+	if flagIDErr != nil {
+		log.Printf("could not convert flag id to object id: %v", flagIDErr)
+		return nil, ErrCouldNotSave
+	}
+
+	flagSettingToSave := &flagSettingMongoModel{
+		ProjectID:     projectIDObjID,
+		EnvironmentID: environmentIDObjID,
+		FlagID:        flagIDObjID,
+		IsActive:      flagSetting.IsActive,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+
+	return flagSettingToSave, nil
 }
 
 func (r *MongoDataRepository) Get(
 	ctx context.Context,
-	projectID primitive.ObjectID,
-	environmentID primitive.ObjectID,
-	flagID primitive.ObjectID,
+	projectID string,
+	environmentID string,
+	flagID string,
 ) (*FlagSetting, error) {
-	query := bson.D{
-		{Key: "project_id", Value: projectID},
-		{Key: "environment_id", Value: environmentID},
-		{Key: "flag_id", Value: flagID},
+	projectIDObjID, projectIDErr := primitive.ObjectIDFromHex(projectID)
+	if projectIDErr != nil {
+		log.Printf("could not convert project id to object id: %v", projectIDErr)
+		return nil, ErrCouldNotSave // TODO: Error
 	}
 
-	var flagSetting FlagSetting
+	environmentIDObjID, environmentIDErr := primitive.ObjectIDFromHex(environmentID)
+	if environmentIDErr != nil {
+		log.Printf("could not convert environment id to object id: %v", environmentIDErr)
+		return nil, ErrCouldNotSave // TODO: Error
+	}
 
-	err := r.coll.FindOne(ctx, query).Decode(&flagSetting)
+	flagIDObjID, flagIDErr := primitive.ObjectIDFromHex(flagID)
+	if flagIDErr != nil {
+		log.Printf("could not convert flag id to object id: %v", flagIDErr)
+		return nil, ErrCouldNotSave // TODO: Error
+	}
+
+	query := bson.D{
+		{Key: "project_id", Value: projectIDObjID},
+		{Key: "environment_id", Value: environmentIDObjID},
+		{Key: "flag_id", Value: flagIDObjID},
+	}
+
+	var decodedFlagSetting flagSettingMongoModel
+
+	err := r.coll.FindOne(ctx, query).Decode(&decodedFlagSetting)
 	if err != nil {
 		return nil, err
 	}
 
-	return &flagSetting, err
+	flagSetting := &FlagSetting{
+		ID:            decodedFlagSetting.ID.Hex(),
+		ProjectID:     decodedFlagSetting.ProjectID.Hex(),
+		EnvironmentID: decodedFlagSetting.EnvironmentID.Hex(),
+		FlagID:        decodedFlagSetting.FlagID.Hex(),
+		IsActive:      decodedFlagSetting.IsActive,
+		CreatedAt:     decodedFlagSetting.CreatedAt,
+		UpdatedAt:     decodedFlagSetting.UpdatedAt,
+	}
+
+	return flagSetting, err
 }
 
 func (r *MongoDataRepository) UpdateIsActive(
 	ctx context.Context,
-	projectID primitive.ObjectID,
-	environmentID primitive.ObjectID,
-	flagID primitive.ObjectID,
+	projectID string,
+	environmentID string,
+	flagID string,
 	isActive bool,
-) (*mongo.UpdateResult, error) {
+) (uint, error) {
+	projectIDObjID, projectIDErr := primitive.ObjectIDFromHex(projectID)
+	if projectIDErr != nil {
+		log.Printf("could not convert project id to object id: %v", projectIDErr)
+		return 0, ErrCouldNotSave // TODO: Error
+	}
+
+	environmentIDObjID, environmentIDErr := primitive.ObjectIDFromHex(environmentID)
+	if environmentIDErr != nil {
+		log.Printf("could not convert environment id to object id: %v", environmentIDErr)
+		return 0, ErrCouldNotSave // TODO: Error
+	}
+
+	flagIDObjID, flagIDErr := primitive.ObjectIDFromHex(flagID)
+	if flagIDErr != nil {
+		log.Printf("could not convert flag id to object id: %v", flagIDErr)
+		return 0, ErrCouldNotSave // TODO: Error
+	}
+
 	filter := bson.D{
-		{Key: "project_id", Value: projectID},
-		{Key: "environment_id", Value: environmentID},
-		{Key: "flag_id", Value: flagID},
+		{Key: "project_id", Value: projectIDObjID},
+		{Key: "environment_id", Value: environmentIDObjID},
+		{Key: "flag_id", Value: flagIDObjID},
 	}
 
 	update := bson.D{{
 		Key: "$set", Value: bson.D{{Key: "is_active", Value: isActive}},
 	}}
 
-	return r.coll.UpdateOne(ctx, filter, update)
+	updateResult, updateErr := r.coll.UpdateOne(ctx, filter, update)
+	if updateErr != nil {
+		log.Printf("could not update status of flag setting: %v", updateErr)
+		return 0, ErrStatusUpdate
+	}
+
+	return uint(updateResult.ModifiedCount), nil
 }
 
 func setupIndexes(ctx context.Context, coll *mongo.Collection) error {

--- a/internal/project/data_model.go
+++ b/internal/project/data_model.go
@@ -5,54 +5,53 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type Project struct {
-	ID           primitive.ObjectID   `bson:"_id,omitempty"`
-	Key          string               `bson:"key"`
-	Name         string               `bson:"name"`
-	Environments []primitive.ObjectID `bson:"environments,omitempty"`
-	Flags        []primitive.ObjectID `bson:"flags,omitempty"`
-	FlagSettings []primitive.ObjectID `bson:"flag_settings,omitempty"`
-	CreatedBy    primitive.ObjectID   `bson:"created_by"`
-	CreatedAt    time.Time            `bson:"created_at"`
-	UpdatedAt    time.Time            `bson:"updated_at"`
+	ID           string
+	Key          string
+	Name         string
+	Environments []string
+	Flags        []string
+	FlagSettings []string
+	CreatedBy    string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 // DataRepository is an interface to the operations that can be performed on
 // the projects collection.
 type DataRepository interface {
-	// Creates a new `Project` document
-	Save(ctx context.Context, project *Project) (*mongo.InsertOneResult, error)
+	// Save creates a new `Project` and returns the ID of the created project.
+	Save(ctx context.Context, project *Project) (string, error)
 
-	// Gets the project by the name and the ID of the user that created the
-	// project.
+	// GetByNameAndUserID gets the project by the name and the ID of the user
+	// that created the project.
 	GetByNameAndUserID(
 		ctx context.Context,
 		projectName string,
-		userID primitive.ObjectID,
+		userID string,
 	) (*Project, error)
 
-	// Adds a new environment to the project by the project name and the user
+	// AddEnvironment adds a new environment ID to the project by the project
 	// ID.
 	AddEnvironment(
 		ctx context.Context,
-		projectID primitive.ObjectID,
+		projectID string,
 		environmentID primitive.ObjectID,
-	) (*mongo.UpdateResult, error)
+	) (uint, error)
 
-	// Adds a new flag to the project by the project name.
+	// AddFlag adds a new flag ID to the project by the project ID.
 	AddFlag(
 		ctx context.Context,
-		projectID primitive.ObjectID,
+		projectID string,
 		flagID primitive.ObjectID,
-	) (*mongo.UpdateResult, error)
+	) (uint, error)
 
-	// AddFlagSettings adds new flag settings to the project.
+	// AddFlagSettings adds new flag setting IDs to the project.
 	AddFlagSettings(
 		ctx context.Context,
 		projectID primitive.ObjectID,
 		flagSettingIDs ...primitive.ObjectID,
-	) (*mongo.UpdateResult, error)
+	) (uint, error)
 }

--- a/internal/project/data_model.go
+++ b/internal/project/data_model.go
@@ -3,8 +3,6 @@ package project
 import (
 	"context"
 	"time"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Project struct {
@@ -38,20 +36,20 @@ type DataRepository interface {
 	AddEnvironment(
 		ctx context.Context,
 		projectID string,
-		environmentID primitive.ObjectID,
+		environmentID string,
 	) (uint, error)
 
 	// AddFlag adds a new flag ID to the project by the project ID.
 	AddFlag(
 		ctx context.Context,
 		projectID string,
-		flagID primitive.ObjectID,
+		flagID string,
 	) (uint, error)
 
 	// AddFlagSettings adds new flag setting IDs to the project.
 	AddFlagSettings(
 		ctx context.Context,
-		projectID primitive.ObjectID,
-		flagSettingIDs ...primitive.ObjectID,
+		projectID string,
+		flagSettingIDs ...string,
 	) (uint, error)
 }

--- a/internal/project/errors.go
+++ b/internal/project/errors.go
@@ -74,3 +74,10 @@ var ErrKeyMetadataLength = status.Error(
 	codes.InvalidArgument,
 	"invalid length of project key metadata",
 )
+
+// ErrProjectIDConvert is a GRPC error that is returned when the project ID
+// could not be converted to the expected type.
+var ErrProjectIDConvert = status.Error(
+	codes.Internal,
+	"could not convert project ID to expected type",
+)

--- a/internal/project/mongo_repo.go
+++ b/internal/project/mongo_repo.go
@@ -2,15 +2,32 @@ package project
 
 import (
 	"context"
+	"errors"
+	"log"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/waduhek/flagger/internal/user"
 )
 
 const ProjectCollection string = "projects"
+
+// projectMongoModel is the MongoDB representation of the `Project` struct.
+type projectMongoModel struct {
+	ID           primitive.ObjectID   `bson:"_id,omitempty"`
+	Key          string               `bson:"key"`
+	Name         string               `bson:"name"`
+	Environments []primitive.ObjectID `bson:"environments,omitempty"`
+	Flags        []primitive.ObjectID `bson:"flags,omitempty"`
+	FlagSettings []primitive.ObjectID `bson:"flag_settings,omitempty"`
+	CreatedBy    primitive.ObjectID   `bson:"created_by"`
+	CreatedAt    time.Time            `bson:"created_at"`
+	UpdatedAt    time.Time            `bson:"updated_at"`
+}
 
 type MongoDataRepository struct {
 	coll *mongo.Collection
@@ -19,33 +36,128 @@ type MongoDataRepository struct {
 func (p *MongoDataRepository) Save(
 	ctx context.Context,
 	project *Project,
-) (*mongo.InsertOneResult, error) {
-	return p.coll.InsertOne(ctx, project)
+) (string, error) {
+	mappedEnvironmentIDs, mapEnvironmentIDErr :=
+		mapStringSliceToObjectIDs(project.Environments)
+	if mapEnvironmentIDErr != nil {
+		log.Printf("could not map environment ids to object ids: %v", mapEnvironmentIDErr)
+		return "", ErrCouldNotSave
+	}
+
+	mappedFlagIDs, mapFlagIDErr := mapStringSliceToObjectIDs(project.Flags)
+	if mapFlagIDErr != nil {
+		log.Printf("could not map flag ids to object ids: %v", mapFlagIDErr)
+		return "", ErrCouldNotSave
+	}
+
+	mappedFlagSettingIDs, mapFlagSettingIDErr :=
+		mapStringSliceToObjectIDs(project.FlagSettings)
+	if mapFlagSettingIDErr != nil {
+		log.Printf("could not map flag setting ids to object ids: %v", mapFlagSettingIDErr)
+		return "", ErrCouldNotSave
+	}
+
+	createdByObjID, createdByObjIDErr := primitive.ObjectIDFromHex(project.CreatedBy)
+	if createdByObjIDErr != nil {
+		log.Printf("could not convert created by to object id: %v", createdByObjIDErr)
+		return "", ErrCouldNotSave
+	}
+
+	projectToAdd := &projectMongoModel{
+		Key:          project.Key,
+		Name:         project.Name,
+		Environments: mappedEnvironmentIDs,
+		Flags:        mappedFlagIDs,
+		FlagSettings: mappedFlagSettingIDs,
+		CreatedBy:    createdByObjID,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	saveResult, saveErr := p.coll.InsertOne(ctx, projectToAdd)
+	if saveErr != nil {
+		if mongo.IsDuplicateKeyError(saveErr) {
+			log.Printf(
+				"a project with name %q exists",
+				project.Name,
+			)
+			return "", ErrNameTaken
+		}
+
+		log.Printf("error occurred while saving project: %v", saveErr)
+		return "", ErrCouldNotSave
+	}
+
+	projectID, ok := saveResult.InsertedID.(primitive.ObjectID)
+	if !ok {
+		log.Printf("could not assert saved project id as object id")
+		return "", ErrCouldNotSave
+	}
+
+	return projectID.Hex(), nil
 }
 
 func (p *MongoDataRepository) GetByNameAndUserID(
 	ctx context.Context,
 	projectName string,
-	userID primitive.ObjectID,
+	userID string,
 ) (*Project, error) {
+	userIDObjectID, userIDErr := primitive.ObjectIDFromHex(userID)
+	if userIDErr != nil {
+		log.Printf("could not convert user ID to ObjectID")
+		return nil, user.ErrUserIDConvert
+	}
+
 	query := bson.D{
-		{Key: "created_by", Value: userID},
+		{Key: "created_by", Value: userIDObjectID},
 		{Key: "name", Value: projectName},
 	}
 
-	var project Project
-	err := p.coll.FindOne(ctx, query).Decode(&project)
+	var decodedProject projectMongoModel
+	findErr := p.coll.FindOne(ctx, query).Decode(&decodedProject)
+	if findErr != nil {
+		log.Printf(
+			"error while getting project %q with user %q: %v",
+			projectName,
+			userID,
+			findErr,
+		)
 
-	return &project, err
+		if errors.Is(findErr, mongo.ErrNoDocuments) {
+			return nil, ErrNotFound
+		}
+
+		return nil, ErrCouldNotFetch
+	}
+
+	project := &Project{
+		ID:           decodedProject.ID.Hex(),
+		Key:          decodedProject.Key,
+		Name:         decodedProject.Name,
+		Environments: mapObjectIDsToStringSlice(decodedProject.Environments),
+		Flags:        mapObjectIDsToStringSlice(decodedProject.Flags),
+		FlagSettings: mapObjectIDsToStringSlice(decodedProject.FlagSettings),
+		CreatedBy:    decodedProject.CreatedBy.Hex(),
+		CreatedAt:    decodedProject.CreatedAt,
+		UpdatedAt:    decodedProject.UpdatedAt,
+	}
+
+	return project, nil
 }
 
 func (p *MongoDataRepository) AddEnvironment(
 	ctx context.Context,
-	projectID primitive.ObjectID,
+	projectID string,
 	environmentID primitive.ObjectID,
-) (*mongo.UpdateResult, error) {
+) (uint, error) {
+	projectIDObjID, projectIDConvertErr := primitive.ObjectIDFromHex(projectID)
+	if projectIDConvertErr != nil {
+		log.Printf("could not convert project ID to ObjectID")
+		return 0, ErrProjectIDConvert
+	}
+
 	filterQuery := bson.D{
-		{Key: "_id", Value: projectID},
+		{Key: "_id", Value: projectIDObjID},
 	}
 	updateQuery := bson.D{
 		{
@@ -58,14 +170,25 @@ func (p *MongoDataRepository) AddEnvironment(
 		},
 	}
 
-	return p.coll.UpdateOne(ctx, filterQuery, updateQuery)
+	updateResult, updateErr := p.coll.UpdateOne(ctx, filterQuery, updateQuery)
+	if updateErr != nil {
+		log.Printf(
+			"error while adding environment %q to project %q: %v",
+			environmentID,
+			projectIDObjID,
+			updateErr,
+		)
+		return 0, ErrAddEnvironment
+	}
+
+	return uint(updateResult.ModifiedCount), nil
 }
 
 func (p *MongoDataRepository) AddFlag(
 	ctx context.Context,
-	projectID primitive.ObjectID,
+	projectID string,
 	flagID primitive.ObjectID,
-) (*mongo.UpdateResult, error) {
+) (uint, error) {
 	filterQuery := bson.D{{Key: "_id", Value: projectID}}
 	updateQuery := bson.D{
 		{
@@ -78,14 +201,24 @@ func (p *MongoDataRepository) AddFlag(
 		},
 	}
 
-	return p.coll.UpdateOne(ctx, filterQuery, updateQuery)
+	updateResult, updateErr := p.coll.UpdateOne(ctx, filterQuery, updateQuery)
+	if updateErr != nil {
+		log.Printf(
+			"error while updating project with the flag: %v",
+			updateErr,
+		)
+
+		return 0, ErrAddFlag
+	}
+
+	return uint(updateResult.ModifiedCount), nil
 }
 
 func (p *MongoDataRepository) AddFlagSettings(
 	ctx context.Context,
-	projectID primitive.ObjectID,
+	projectID string,
 	flagSettingIDs ...primitive.ObjectID,
-) (*mongo.UpdateResult, error) {
+) (uint, error) {
 	filter := bson.D{{Key: "_id", Value: projectID}}
 	update := bson.D{
 		{
@@ -103,7 +236,16 @@ func (p *MongoDataRepository) AddFlagSettings(
 		},
 	}
 
-	return p.coll.UpdateOne(ctx, filter, update)
+	updateResult, updateErr := p.coll.UpdateOne(ctx, filter, update)
+	if updateErr != nil {
+		log.Printf(
+			"error while updating project with flag settings: %v",
+			updateErr,
+		)
+		return 0, ErrAddFlagSetting
+	}
+
+	return uint(updateResult.ModifiedCount), nil
 }
 
 func setupProjectCollIndexes(
@@ -133,6 +275,31 @@ func setupProjectCollIndexes(
 	)
 
 	return err
+}
+
+func mapStringSliceToObjectIDs(s []string) ([]primitive.ObjectID, error) {
+	mappedObjectIDs := make([]primitive.ObjectID, len(s))
+
+	for _, id := range s {
+		currentID, err := primitive.ObjectIDFromHex(id)
+		if err != nil {
+			return []primitive.ObjectID{}, err
+		}
+
+		mappedObjectIDs = append(mappedObjectIDs, currentID)
+	}
+
+	return mappedObjectIDs, nil
+}
+
+func mapObjectIDsToStringSlice(s []primitive.ObjectID) []string {
+	mappedStrings := make([]string, len(s))
+
+	for _, id := range s {
+		mappedStrings = append(mappedStrings, id.Hex())
+	}
+
+	return mappedStrings
 }
 
 func NewProjectRepository(

--- a/internal/project/service_grpc.go
+++ b/internal/project/service_grpc.go
@@ -2,11 +2,7 @@ package project
 
 import (
 	"context"
-	"errors"
 	"log"
-	"time"
-
-	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/waduhek/flagger/proto/projectpb"
 
@@ -49,8 +45,6 @@ func (p *Server) CreateNewProject(
 		Name:      projectName,
 		Key:       generateProjectKey(projectKeyLen),
 		CreatedBy: fetchedUser.ID,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
 	}
 
 	var projectErr error
@@ -68,17 +62,7 @@ func (p *Server) CreateNewProject(
 	// If all attempts to save the project were unsuccessful, then return the
 	// error.
 	if projectErr != nil {
-		if mongo.IsDuplicateKeyError(projectErr) {
-			log.Printf(
-				"a project with name %q exists for user %q",
-				projectName,
-				username,
-			)
-			return nil, ErrNameTaken
-		}
-
-		log.Printf("error while creating new project: %v", projectErr)
-		return nil, ErrCouldNotSave
+		return nil, projectErr
 	}
 
 	return &projectpb.CreateNewProjectResponse{}, nil
@@ -109,18 +93,7 @@ func (p *Server) GetProjectKey(
 		fetchedUser.ID,
 	)
 	if err != nil {
-		log.Printf(
-			"error while fetching project %q with user %q: %v",
-			projectName,
-			username,
-			err,
-		)
-
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, ErrNotFound
-		}
-
-		return nil, ErrCouldNotFetch
+		return nil, err
 	}
 
 	response := projectpb.GetProjectKeyResponse{ProjectKey: project.Key}

--- a/internal/project/service_grpc.go
+++ b/internal/project/service_grpc.go
@@ -40,8 +40,7 @@ func (p *Server) CreateNewProject(
 
 	fetchedUser, err := p.userDataRepo.GetByUsername(ctx, username)
 	if err != nil {
-		log.Printf("error while fetching user %q: %v", username, err)
-		return nil, user.ErrCouldNotFetch
+		return nil, err
 	}
 
 	projectName := req.GetProjectName()
@@ -99,8 +98,7 @@ func (p *Server) GetProjectKey(
 
 	fetchedUser, err := p.userDataRepo.GetByUsername(ctx, username)
 	if err != nil {
-		log.Printf("error while fetching user %q: %v", username, err)
-		return nil, user.ErrCouldNotFetch
+		return nil, err
 	}
 
 	projectName := req.GetProjectName()

--- a/internal/user/errors.go
+++ b/internal/user/errors.go
@@ -32,3 +32,10 @@ var ErrNotSaved = status.Error(
 // ErrPasswordUpdate is a GRPC error that occurs when the password could not be
 // updated.
 var ErrPasswordUpdate = status.Error(codes.Internal, "could not save password")
+
+// ErrUserIDConvert is a GRPC error that is returned when the user ID could not
+// be converted to the expected type.
+var ErrUserIDConvert = status.Error(
+	codes.Internal,
+	"could not convert user ID to expected format",
+)

--- a/internal/user/model.go
+++ b/internal/user/model.go
@@ -1,11 +1,6 @@
 package user
 
-import (
-	"context"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
-)
+import "context"
 
 // Password is the password information for a user. This struct will be inlined
 // with the User struct.
@@ -16,26 +11,28 @@ type Password struct {
 
 // The details of the user.
 type User struct {
-	ID       primitive.ObjectID `bson:"_id,omitempty"`
-	Name     string             `bson:"name" json:"name"`
-	Email    string             `bson:"email" json:"email"`
-	Username string             `bson:"username" json:"username"`
-	Password Password           `bson:"inline" json:"password"`
+	ID       string
+	Name     string
+	Email    string
+	Username string
+	Password *Password
 }
 
 // DataRepository is an interface to the operations that can be performed on the
 // users collection.
 type DataRepository interface {
-	// Save saves the details of the user to the collection.
-	Save(ctx context.Context, user *User) (*mongo.InsertOneResult, error)
+	// Save saves the details of the user to the collection and returns the ID
+	// of the saved user.
+	Save(ctx context.Context, user *User) (string, error)
 
-	// GetByUsername fetches the details of the user by their username.
+	// GetByUsername gets the details of the user by their username.
 	GetByUsername(ctx context.Context, username string) (*User, error)
 
-	// UpdatePassword updates the password of the user by the username.
+	// UpdatePassword updates the password of the user by the username and
+	// returns the number of records that were updated.
 	UpdatePassword(
 		ctx context.Context,
 		username string,
 		password *Password,
-	) (*mongo.UpdateResult, error)
+	) (uint, error)
 }


### PR DESCRIPTION
Convert all model and repository interfaces that are MongoDB specific to generic interfaces.